### PR TITLE
Add dev container support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/rust:2-1-trixie
+RUN sudo apt update && sudo apt upgrade -y
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+RUN cargo binstall -y wasm-tools
+RUN cargo binstall -y wkg
+RUN cargo binstall -y wac-cli
+RUN cargo binstall -y wasmtime-cli

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "logging",
+	"build": {
+        "dockerfile": "Dockerfile"
+    },
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	"mounts": [
+		{
+			"source": "devcontainer-cargo-cache-${devcontainerId}",
+			"target": "/usr/local/cargo",
+			"type": "volume"
+		},
+		{
+			"source": "devcontainer-rustup-cache-${devcontainerId}",
+			"target": "/usr/local/rustup",
+			"type": "volume"
+		}
+	],
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "cargo check",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"dev.containers.githubCLILoginWithToken": true
+			},
+			"extensions": [
+				"bytecodealliance.wit-idl",
+				"github.vscode-github-actions",
+				"ms-azuretools.vscode-containers",
+				"rust-lang.rust-analyzer",
+				"streetsidesoftware.code-spell-checker",
+				"tamasfe.even-better-toml",
+				"vadimcn.vscode-lldb"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+- package-ecosystem: devcontainers
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A collection of utility components that remix wasi:logging types and interfaces.
 
 ## Build
 
+A [dev container](https://containers.dev) is available that contains the necessary tools and configuration out of the box.
+
 Prereqs:
 - a rust toolchain
 - [`cargo component`](https://github.com/bytecodealliance/cargo-component)


### PR DESCRIPTION
A dev container can be used to develop and build this project. App specific settings are included for VS Code.